### PR TITLE
added an initial calendar date to allow for bi-directional pagination

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -94,7 +94,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.4"
+    version: "1.0.5"
   path:
     dependency: transitive
     description:
@@ -155,7 +155,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -169,7 +169,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.22.0"

--- a/lib/paged_vertical_calendar.dart
+++ b/lib/paged_vertical_calendar.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart' hide DateUtils;
 import 'package:flutter/rendering.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
-import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
 import 'package:paged_vertical_calendar/utils/date_models.dart';
 import 'package:paged_vertical_calendar/utils/date_utils.dart';

--- a/lib/paged_vertical_calendar.dart
+++ b/lib/paged_vertical_calendar.dart
@@ -36,6 +36,8 @@ class PagedVerticalCalendar extends StatefulWidget {
     this.physics,
     this.scrollController,
     this.listPadding = EdgeInsets.zero,
+    this.languageCode,
+    this.initialIndex,
   });
 
   /// the [DateTime] to start the calendar from, if no [startDate] is provided
@@ -85,85 +87,190 @@ class PagedVerticalCalendar extends StatefulWidget {
 
   /// scroll controller for making programmable scroll interactions
   final ScrollController? scrollController;
+  
+  /// Language Code String
+  final String languageCode;
+
+  /// init with this index
+  final int initialIndex;
 
   @override
   _PagedVerticalCalendarState createState() => _PagedVerticalCalendarState();
 }
 
 class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
-  late PagingController<int, Month> controller;
+  late PagingController<int, Month> _pagingReplyUpController;
+  late PagingController<int, Month> _pagingReplyDownController;
 
   @override
   void initState() {
     super.initState();
-    controller = PagingController<int, Month>(
+    _pagingReplyUpController = PagingController<int, Month>(
       firstPageKey: 0,
       invisibleItemsThreshold: widget.invisibleMonthsThreshold,
     );
-    controller.addPageRequestListener(fetchItems);
-    controller.addStatusListener(paginationStatus);
+    _pagingReplyUpController.addPageRequestListener(_fetchUpPage);
+    _pagingReplyUpController.addStatusListener(paginationStatusUp);
+
+    _pagingReplyDownController = PagingController<int, Month>(
+      firstPageKey: 0,
+      invisibleItemsThreshold: widget.invisibleMonthsThreshold,
+    );
+    _pagingReplyDownController.addPageRequestListener(_fetchDownPage);
+    _pagingReplyDownController.addStatusListener(paginationStatusDown);
   }
 
-  void paginationStatus(PagingStatus state) {
+  void paginationStatusUp(PagingStatus state) {
+    //print(PagingStatus);
     if (state == PagingStatus.completed)
-      return widget.onPaginationCompleted?.call();
+      return widget.onPaginationCompleted.call();
+  }
+
+  void paginationStatusDown(PagingStatus state) {
+    //print(PagingStatus);
+    if (state == PagingStatus.completed)
+      return widget.onPaginationCompleted.call();
   }
 
   /// fetch a new [Month] object based on the [pageKey] which is the Nth month
   /// from the start date
-  void fetchItems(int pageKey) async {
+  void _fetchUpPage(int pageKey) async {
+    print("fetch up: " + pageKey.toString());
+    try {
+      final month = DateUtils.getMonth(
+          DateTime(
+              widget.startDate.year,
+              widget.startDate.month + widget.initialIndex,
+              widget.startDate.day),
+          widget.endDate,
+          pageKey + 1,
+          true);
+
+      WidgetsBinding.instance?.addPostFrameCallback(
+        (_) => widget.onMonthLoaded.call(month.year, month.month),
+      );
+
+      final newItems = [month];
+      final isLastPage = widget.startDate != null &&
+          widget.startDate.isSameDayOrAfter(month.weeks.first.firstDay);
+
+      if (isLastPage) {
+        return _pagingReplyUpController.appendLastPage(newItems);
+      }
+
+      final nextPageKey = pageKey + newItems.length;
+      _pagingReplyUpController.appendPage(newItems, nextPageKey);
+    } catch (_) {
+      _pagingReplyUpController.error;
+    }
+  }
+
+  void _fetchDownPage(int pageKey) async {
+    print("fetch down: " + pageKey.toString());
     try {
       final month = DateUtils.getMonth(
         widget.startDate,
         widget.endDate,
-        pageKey,
+        pageKey + widget.initialIndex,
+        false,
       );
 
       WidgetsBinding.instance?.addPostFrameCallback(
-        (_) => widget.onMonthLoaded?.call(month.year, month.month),
+        (_) => widget.onMonthLoaded.call(month.year, month.month),
       );
 
       final newItems = [month];
       final isLastPage = widget.endDate != null &&
-          widget.endDate!.isSameDayOrBefore(month.weeks.last.lastDay);
+          widget.endDate.isSameDayOrBefore(month.weeks.last.lastDay);
 
-      if (isLastPage) return controller.appendLastPage(newItems);
+      if (isLastPage) {
+        return _pagingReplyDownController.appendLastPage(newItems);
+      }
 
       final nextPageKey = pageKey + newItems.length;
-      controller.appendPage(newItems, nextPageKey);
+      _pagingReplyDownController.appendPage(newItems, nextPageKey);
     } catch (_) {
-      controller.error;
+      _pagingReplyDownController.error;
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox.expand(
-      child: PagedListView<int, Month>(
-        addAutomaticKeepAlives: widget.addAutomaticKeepAlives,
-        padding: widget.listPadding,
-        pagingController: controller,
-        physics: widget.physics,
-        scrollController: widget.scrollController,
-        builderDelegate: PagedChildBuilderDelegate<Month>(
-          itemBuilder: (BuildContext context, Month month, int index) {
-            return _MonthView(
-              month: month,
-              monthBuilder: widget.monthBuilder,
-              dayBuilder: widget.dayBuilder,
-              onDayPressed: widget.onDayPressed,
-            );
-          },
-        ),
-      ),
+    return Scrollable(
+      viewportBuilder: (BuildContext context, ViewportOffset position) {
+        return Viewport(
+          offset: position,
+          center: downListKey,
+          slivers: [
+            PagedSliverList(
+              pagingController: _pagingReplyUpController,
+              builderDelegate: PagedChildBuilderDelegate<Month>(
+                itemBuilder: (BuildContext context, Month month, int index) {
+                  return _MonthView(
+                    month: month,
+                    monthBuilder: widget.monthBuilder,
+                    dayBuilder: widget.dayBuilder,
+                    onDayPressed: widget.onDayPressed,
+                    languageCode: widget.languageCode,
+                  );
+                },
+              ),
+            ),
+            PagedSliverList(
+              key: downListKey,
+              pagingController: _pagingReplyDownController,
+              builderDelegate: PagedChildBuilderDelegate<Month>(
+                itemBuilder: (BuildContext context, Month month, int index) {
+                  return _MonthView(
+                    month: month,
+                    monthBuilder: widget.monthBuilder,
+                    dayBuilder: widget.dayBuilder,
+                    onDayPressed: widget.onDayPressed,
+                    languageCode: widget.languageCode,
+                  );
+                },
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 
   @override
   void dispose() {
-    controller.dispose();
+    _pagingReplyUpController.dispose();
+    _pagingReplyDownController.dispose();
     super.dispose();
   }
+}
+
+List<String> getDaysOfWeek([String locale = 'en']) {
+  var today = DateTime.now();
+
+  while (today.weekday != DateTime.monday) {
+    today = today.subtract(const Duration(days: 1));
+  }
+  final dateFormat = DateFormat(DateFormat.ABBR_WEEKDAY, locale);
+  final daysOfWeek = [
+    dateFormat.format(today),
+    dateFormat.format(today.add(const Duration(days: 1))),
+    dateFormat.format(today.add(const Duration(days: 2))),
+    dateFormat.format(today.add(const Duration(days: 3))),
+    dateFormat.format(today.add(const Duration(days: 4))),
+    dateFormat.format(today.add(const Duration(days: 5))),
+    dateFormat.format(today.add(const Duration(days: 6)))
+  ];
+
+  return daysOfWeek;
+}
+
+Widget _pattern(BuildContext context, String weekday) {
+  return Center(
+    child: Text(
+      weekday.toUpperCase(),
+    ),
+  );
 }
 
 class _MonthView extends StatelessWidget {
@@ -172,25 +279,42 @@ class _MonthView extends StatelessWidget {
     this.monthBuilder,
     this.dayBuilder,
     this.onDayPressed,
+    this.languageCode,
   });
 
   final Month month;
   final MonthBuilder? monthBuilder;
   final DayBuilder? dayBuilder;
   final ValueChanged<DateTime>? onDayPressed;
+  final String languageCode;
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: <Widget>[
         /// display the default month header if none is provided
-        monthBuilder?.call(context, month.month, month.year) ??
-            _DefaultMonthView(month: month.month, year: month.year),
-
+        monthBuilder.call(context, month.month, month.year) ??
+            _DefaultMonthView(
+              month: month.month,
+              year: month.year,
+              languageCode: languageCode,
+            ),
+        GridView.count(
+            crossAxisCount: DateTime.daysPerWeek,
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            padding: EdgeInsets.zero,
+            children: List.generate(DateTime.daysPerWeek, (index) {
+              final weekDay = getDaysOfWeek(languageCode)[index];
+              return _pattern(context, weekDay);
+            })),
         Table(
           children: month.weeks.map((Week week) {
             return _generateWeekRow(context, week);
           }).toList(growable: false),
+        ),
+        SizedBox(
+          height: 20,
         ),
       ],
     );
@@ -232,15 +356,16 @@ class _MonthView extends StatelessWidget {
 class _DefaultMonthView extends StatelessWidget {
   final int month;
   final int year;
+  final String languageCode;
 
-  _DefaultMonthView({required this.month, required this.year});
+  _DefaultMonthView({required this.month, required this.year, this.languageCode});
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: Text(
-        DateFormat('MMMM yyyy').format(DateTime(year, month)),
+        DateFormat.yMMMM(languageCode).format(DateTime(year, month)),
         style: Theme.of(context).textTheme.headline6,
       ),
     );

--- a/lib/paged_vertical_calendar.dart
+++ b/lib/paged_vertical_calendar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart' hide DateUtils;
+import 'package:flutter/rendering.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:intl/intl.dart';
 import 'package:paged_vertical_calendar/utils/date_models.dart';
@@ -89,10 +90,10 @@ class PagedVerticalCalendar extends StatefulWidget {
   final ScrollController? scrollController;
   
   /// Language Code String
-  final String languageCode;
+  final String? languageCode;
 
   /// init with this index
-  final int initialIndex;
+  final int? initialIndex;
 
   @override
   _PagedVerticalCalendarState createState() => _PagedVerticalCalendarState();
@@ -101,6 +102,8 @@ class PagedVerticalCalendar extends StatefulWidget {
 class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
   late PagingController<int, Month> _pagingReplyUpController;
   late PagingController<int, Month> _pagingReplyDownController;
+
+  final Key downListKey = UniqueKey();
 
   @override
   void initState() {
@@ -123,13 +126,13 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
   void paginationStatusUp(PagingStatus state) {
     //print(PagingStatus);
     if (state == PagingStatus.completed)
-      return widget.onPaginationCompleted.call();
+      return widget.onPaginationCompleted?.call();
   }
 
   void paginationStatusDown(PagingStatus state) {
     //print(PagingStatus);
     if (state == PagingStatus.completed)
-      return widget.onPaginationCompleted.call();
+      return widget.onPaginationCompleted?.call();
   }
 
   /// fetch a new [Month] object based on the [pageKey] which is the Nth month
@@ -139,20 +142,20 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
     try {
       final month = DateUtils.getMonth(
           DateTime(
-              widget.startDate.year,
-              widget.startDate.month + widget.initialIndex,
-              widget.startDate.day),
+              widget.startDate!.year,
+              widget.startDate!.month + widget.initialIndex!,
+              widget.startDate!.day),
           widget.endDate,
           pageKey + 1,
           true);
 
       WidgetsBinding.instance?.addPostFrameCallback(
-        (_) => widget.onMonthLoaded.call(month.year, month.month),
+        (_) => widget.onMonthLoaded?.call(month.year, month.month),
       );
 
       final newItems = [month];
       final isLastPage = widget.startDate != null &&
-          widget.startDate.isSameDayOrAfter(month.weeks.first.firstDay);
+          widget.startDate!.isSameDayOrAfter(month.weeks.first.firstDay);
 
       if (isLastPage) {
         return _pagingReplyUpController.appendLastPage(newItems);
@@ -171,17 +174,17 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
       final month = DateUtils.getMonth(
         widget.startDate,
         widget.endDate,
-        pageKey + widget.initialIndex,
+        pageKey + widget.initialIndex!,
         false,
       );
 
       WidgetsBinding.instance?.addPostFrameCallback(
-        (_) => widget.onMonthLoaded.call(month.year, month.month),
+        (_) => widget.onMonthLoaded?.call(month.year, month.month),
       );
 
       final newItems = [month];
       final isLastPage = widget.endDate != null &&
-          widget.endDate.isSameDayOrBefore(month.weeks.last.lastDay);
+          widget.endDate!.isSameDayOrBefore(month.weeks.last.lastDay);
 
       if (isLastPage) {
         return _pagingReplyDownController.appendLastPage(newItems);
@@ -211,7 +214,7 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
                     monthBuilder: widget.monthBuilder,
                     dayBuilder: widget.dayBuilder,
                     onDayPressed: widget.onDayPressed,
-                    languageCode: widget.languageCode,
+                    languageCode: widget.languageCode!,
                   );
                 },
               ),
@@ -226,7 +229,7 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
                     monthBuilder: widget.monthBuilder,
                     dayBuilder: widget.dayBuilder,
                     onDayPressed: widget.onDayPressed,
-                    languageCode: widget.languageCode,
+                    languageCode: widget.languageCode!,
                   );
                 },
               ),
@@ -286,18 +289,18 @@ class _MonthView extends StatelessWidget {
   final MonthBuilder? monthBuilder;
   final DayBuilder? dayBuilder;
   final ValueChanged<DateTime>? onDayPressed;
-  final String languageCode;
+  final String? languageCode;
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: <Widget>[
         /// display the default month header if none is provided
-        monthBuilder.call(context, month.month, month.year) ??
+        monthBuilder?.call(context, month.month, month.year) ??
             _DefaultMonthView(
               month: month.month,
               year: month.year,
-              languageCode: languageCode,
+              languageCode: languageCode!,
             ),
         GridView.count(
             crossAxisCount: DateTime.daysPerWeek,
@@ -305,7 +308,7 @@ class _MonthView extends StatelessWidget {
             physics: const NeverScrollableScrollPhysics(),
             padding: EdgeInsets.zero,
             children: List.generate(DateTime.daysPerWeek, (index) {
-              final weekDay = getDaysOfWeek(languageCode)[index];
+              final weekDay = getDaysOfWeek(languageCode!)[index];
               return _pattern(context, weekDay);
             })),
         Table(
@@ -356,7 +359,7 @@ class _MonthView extends StatelessWidget {
 class _DefaultMonthView extends StatelessWidget {
   final int month;
   final int year;
-  final String languageCode;
+  final String? languageCode;
 
   _DefaultMonthView({required this.month, required this.year, this.languageCode});
 

--- a/lib/paged_vertical_calendar.dart
+++ b/lib/paged_vertical_calendar.dart
@@ -285,16 +285,12 @@ class _MonthView extends StatelessWidget {
     this.monthBuilder,
     this.dayBuilder,
     this.onDayPressed,
-    this.languageCode,
-    this.weekDays = true,
   });
 
   final Month month;
   final MonthBuilder? monthBuilder;
   final DayBuilder? dayBuilder;
   final ValueChanged<DateTime>? onDayPressed;
-  final String? languageCode;
-  final bool weekDays;
 
   @override
   Widget build(BuildContext context) {
@@ -371,9 +367,8 @@ class _DefaultMonthView extends StatelessWidget {
 
 class _DefaultDayView extends StatelessWidget {
   final DateTime date;
-  final bool? isSelected;
 
-  _DefaultDayView({required this.date, this.isSelected});
+  _DefaultDayView({required this.date});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/paged_vertical_calendar.dart
+++ b/lib/paged_vertical_calendar.dart
@@ -110,6 +110,16 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
   @override
   void initState() {
     super.initState();
+
+    int years = DateTime.now().year - widget.startDate!.year;
+    int months = DateTime.now().month - widget.endDate!.month;
+    int days = DateTime.now().day - widget.startDate!.day;
+
+    if (years > 0) {
+      months += (years * 12);
+    }
+    initialIndex = months;
+
     _pagingReplyUpController = PagingController<int, Month>(
       firstPageKey: 0,
       invisibleItemsThreshold: widget.invisibleMonthsThreshold,
@@ -123,15 +133,6 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
     );
     _pagingReplyDownController.addPageRequestListener(_fetchDownPage);
     _pagingReplyDownController.addStatusListener(paginationStatusDown);
-
-    int years = DateTime.now().year - widget.startDate!.year;
-    int months = DateTime.now().month - widget.endDate!.month;
-    int days = DateTime.now().day - widget.startDate!.day;
-
-    if (years > 0) {
-      months += (years * 12);
-    }
-    initialIndex = months;
   }
 
   void paginationStatusUp(PagingStatus state) {

--- a/lib/paged_vertical_calendar.dart
+++ b/lib/paged_vertical_calendar.dart
@@ -94,9 +94,10 @@ class PagedVerticalCalendar extends StatefulWidget {
   /// Language Code String
   final String? languageCode;
 
-  /// init with this Date. Its necessary to have startDate
+  /// init with this Date. If no startDate is given, it takes DateTime.now().
   final DateTime? initDate;
 
+  /// defaults to true. Show weekDays or not
   final bool weekDays;
 
   @override
@@ -122,7 +123,6 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
     if (widget.initDate != null) {
       if (widget.endDate != null) {
         int diffDays = widget.endDate!.difference(widget.initDate!).inDays;
-        //print("diffDays: " + diffDays.toString());
         if (diffDays.isNegative) {
           initialDate = widget.endDate!;
         } else {
@@ -148,7 +148,6 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
       months += (years * 12);
     }
     initialIndex = months;
-    print(years);
 
     _pagingReplyUpController = PagingController<int, Month>(
       firstPageKey: 0,
@@ -166,13 +165,11 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
   }
 
   void paginationStatusUp(PagingStatus state) {
-    //print(PagingStatus);
     if (state == PagingStatus.completed)
       return widget.onPaginationCompleted?.call();
   }
 
   void paginationStatusDown(PagingStatus state) {
-    //print(PagingStatus);
     if (state == PagingStatus.completed)
       return widget.onPaginationCompleted?.call();
   }
@@ -180,8 +177,6 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
   /// fetch a new [Month] object based on the [pageKey] which is the Nth month
   /// from the start date
   void _fetchUpPage(int pageKey) async {
-    // print("fetch up: " + pageKey.toString());
-
     DateTime startDateUp = widget.startDate != null
         ? DateTime(widget.startDate!.year,
             widget.startDate!.month + initialIndex, widget.startDate!.day)
@@ -211,7 +206,6 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
   }
 
   void _fetchDownPage(int pageKey) async {
-    // print("fetch down: " + pageKey.toString());
     try {
       final month = DateUtils.getMonth(
         widget.startDate,

--- a/lib/paged_vertical_calendar.dart
+++ b/lib/paged_vertical_calendar.dart
@@ -38,7 +38,7 @@ class PagedVerticalCalendar extends StatefulWidget {
     this.scrollController,
     this.listPadding = EdgeInsets.zero,
     this.languageCode,
-    this.initialIndex,
+    this.initDate,
   });
 
   /// the [DateTime] to start the calendar from, if no [startDate] is provided
@@ -88,12 +88,12 @@ class PagedVerticalCalendar extends StatefulWidget {
 
   /// scroll controller for making programmable scroll interactions
   final ScrollController? scrollController;
-  
+
   /// Language Code String
   final String? languageCode;
 
-  /// init with this index
-  final int? initialIndex;
+  /// init with this Date
+  final DateTime? initDate;
 
   @override
   _PagedVerticalCalendarState createState() => _PagedVerticalCalendarState();
@@ -104,6 +104,8 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
   late PagingController<int, Month> _pagingReplyDownController;
 
   final Key downListKey = UniqueKey();
+
+  late int initialIndex;
 
   @override
   void initState() {
@@ -121,6 +123,15 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
     );
     _pagingReplyDownController.addPageRequestListener(_fetchDownPage);
     _pagingReplyDownController.addStatusListener(paginationStatusDown);
+
+    int years = DateTime.now().year - widget.startDate!.year;
+    int months = DateTime.now().month - widget.endDate!.month;
+    int days = DateTime.now().day - widget.startDate!.day;
+
+    if (years > 0) {
+      months += (years * 12);
+    }
+    initialIndex = months;
   }
 
   void paginationStatusUp(PagingStatus state) {
@@ -141,10 +152,8 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
     print("fetch up: " + pageKey.toString());
     try {
       final month = DateUtils.getMonth(
-          DateTime(
-              widget.startDate!.year,
-              widget.startDate!.month + widget.initialIndex!,
-              widget.startDate!.day),
+          DateTime(widget.startDate!.year,
+              widget.startDate!.month + initialIndex!, widget.startDate!.day),
           widget.endDate,
           pageKey + 1,
           true);
@@ -174,7 +183,7 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
       final month = DateUtils.getMonth(
         widget.startDate,
         widget.endDate,
-        pageKey + widget.initialIndex!,
+        pageKey + initialIndex!,
         false,
       );
 
@@ -361,7 +370,8 @@ class _DefaultMonthView extends StatelessWidget {
   final int year;
   final String? languageCode;
 
-  _DefaultMonthView({required this.month, required this.year, this.languageCode});
+  _DefaultMonthView(
+      {required this.month, required this.year, this.languageCode});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/utils/date_utils.dart
+++ b/lib/utils/date_utils.dart
@@ -2,7 +2,8 @@ import 'package:paged_vertical_calendar/utils/date_models.dart';
 
 class DateUtils {
   /// generates a [Month] object from the Nth index from the startdate
-  static Month getMonth(DateTime? minDate, DateTime? maxDate, int monthPage, bool up) {
+  static Month getMonth(
+      DateTime? minDate, DateTime? maxDate, int monthPage, bool up) {
     // if no start date is provided use the current date
     DateTime startDate = (minDate ?? DateTime.now()).removeTime();
 

--- a/lib/utils/date_utils.dart
+++ b/lib/utils/date_utils.dart
@@ -2,14 +2,18 @@ import 'package:paged_vertical_calendar/utils/date_models.dart';
 
 class DateUtils {
   /// generates a [Month] object from the Nth index from the startdate
-  static Month getMonth(DateTime? minDate, DateTime? maxDate, int monthPage) {
+  static Month getMonth(DateTime? minDate, DateTime? maxDate, int monthPage, bool up) {
     // if no start date is provided use the current date
     DateTime startDate = (minDate ?? DateTime.now()).removeTime();
 
     // if this is not the first month in this calendar then calculate a new
     // start date for this month
     if (monthPage > 0) {
-      startDate = DateTime(startDate.year, startDate.month + monthPage, 1);
+      if (up) {
+        startDate = DateTime(startDate.year, startDate.month - monthPage, 1);
+      } else {
+        startDate = DateTime(startDate.year, startDate.month + monthPage, 1);
+      }
     }
 
     // find the first day of the first week in this month

--- a/lib/utils/date_utils.dart
+++ b/lib/utils/date_utils.dart
@@ -11,8 +11,10 @@ class DateUtils {
     // start date for this month
     if (monthPage > 0) {
       if (up) {
+        // fetsch up: month will be subtructed
         startDate = DateTime(startDate.year, startDate.month - monthPage, 1);
       } else {
+        // fetch down: month will be added
         startDate = DateTime(startDate.year, startDate.month + monthPage, 1);
       }
     }
@@ -34,16 +36,35 @@ class DateUtils {
       // if an endDate is provided we need to check if the current week extends
       // beyond this date. if it does, cap the week to the endDate and stop the
       // loop
-      if (maxDate != null && lastDayOfWeek.isSameDayOrAfter(maxDate)) {
-        Week week = Week(firstDayOfWeek, maxDate);
+
+      if (up) {
+        // fetching up
+        Week week;
+        if (maxDate != null && firstDayOfWeek.isBefore(maxDate)) {
+          week = Week(maxDate, lastDayOfWeek);
+        } else {
+          week = Week(firstDayOfWeek, lastDayOfWeek);
+        }
+
+        if (maxDate != null && lastDayOfWeek.isSameDayOrAfter(maxDate)) {
+          weeks.add(week);
+        } else if (maxDate == null) {
+          weeks.add(week);
+        }
+        if (week.isLastWeekOfMonth) break;
+      } else {
+        // fetching down
+        if (maxDate != null && lastDayOfWeek.isSameDayOrAfter(maxDate)) {
+          Week week = Week(firstDayOfWeek, maxDate);
+          weeks.add(week);
+          break;
+        }
+
+        Week week = Week(firstDayOfWeek, lastDayOfWeek);
         weeks.add(week);
-        break;
+
+        if (week.isLastWeekOfMonth) break;
       }
-
-      Week week = Week(firstDayOfWeek, lastDayOfWeek);
-      weeks.add(week);
-
-      if (week.isLastWeekOfMonth) break;
 
       firstDayOfWeek = lastDayOfWeek.nextDay;
       lastDayOfWeek = _lastDayOfWeek(firstDayOfWeek);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -148,7 +155,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -148,7 +148,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -162,7 +162,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.22.0"

--- a/test/vertical_calendar_test.dart
+++ b/test/vertical_calendar_test.dart
@@ -6,7 +6,7 @@ import 'package:paged_vertical_calendar/utils/date_utils.dart';
 void main() {
   group('utils', () {
     test('get a month without provided dates', () {
-      final month = DateUtils.getMonth(null, null, 0);
+      final month = DateUtils.getMonth(null, null, 0, true);
       expect(month, isNotNull);
       expect(month.month, DateTime.now().month);
       expect(month.daysInMonth,
@@ -14,7 +14,7 @@ void main() {
     });
 
     test('get a month with provided start date', () {
-      final month = DateUtils.getMonth(DateTime(2020, 1, 1), null, 0);
+      final month = DateUtils.getMonth(DateTime(2020, 1, 1), null, 0, true);
       expect(month, isNotNull);
       expect(month.month, 1);
       expect(month.daysInMonth,
@@ -23,8 +23,8 @@ void main() {
     });
 
     test('get a month with provided end date', () {
-      final month =
-          DateUtils.getMonth(DateTime(2020, 1, 1), DateTime(2020, 5, 1), 4);
+      final month = DateUtils.getMonth(
+          DateTime(2020, 1, 1), DateTime(2020, 5, 1), 4, true);
       expect(month, isNotNull);
       expect(month.month, 5);
       expect(month.daysInMonth,


### PR DESCRIPTION
Added the functionality to use an initial date to which the calendar jumps at start. I have orientated on this principle:
https://github.com/EdsonBueno/infinite_scroll_pagination/issues/56#issuecomment-890392710
If no startDate is given, it takes DateTime.now(). same for initDate. If initDate is larger than endDate, it is taken endDate.
In addition I added a localization parameter and weekdays as option.

Example:

```
PagedVerticalCalendar(
      invisibleMonthsThreshold: 1,
      startDate: DateTime(2021, 9, 1),
      endDate: DateTime(2022, 3, 1),
      initDate: DateTime(2022, 2, 1),
      weekDays: true,
      languageCode: 'de',
      onMonthLoaded: (year, month) {
        // on month widget load
      },
      onDayPressed: (value) {
        // on day widget pressed
      },
      onPaginationCompleted: () {
        // on pagination completion
      },
    )
```
