### PR TITLE
fix: ignore time when adding days

### DIFF
--- a/lib/utils/date_utils.dart
+++ b/lib/utils/date_utils.dart
@@ -104,7 +104,7 @@ abstract class DateUtils {
 
     return firstDayOfWeek.day + restOfWeek > daysInMonth
         ? DateTime(firstDayOfWeek.year, firstDayOfWeek.month, daysInMonth)
-        : firstDayOfWeek.add(Duration(days: restOfWeek));
+        : firstDayOfWeek.addDays(restOfWeek);
   }
 
   static DateTime _findDayOfWeekInMonth(
@@ -160,4 +160,17 @@ extension DateUtilsExtensions on DateTime {
 
   bool isSameMonth(DateTime other) =>
       other.year == year && other.month == month;
+
+  DateTime addDays(int daysToAdd) {
+    return DateTime(
+      this.year,
+      this.month,
+      this.day + daysToAdd,
+      this.hour,
+      this.minute,
+      this.second,
+      this.millisecond,
+      this.microsecond,
+    );
+  }
 }


### PR DESCRIPTION
Hi! We noticed an issue regarding the display of the calendar weeks. This is related to daylight saving time (we are based in Chile, where we set our clocks back the first week of April). Here is proof of the issue when compiling the provided example:

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-28 at 15 24 07](https://user-images.githubusercontent.com/14048037/221958731-1eb7440c-6219-48ff-8c24-ec24c321123b.png)

This is a problem that occurs across years. The previous example was of the year 2023, and the following is of 2025:

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-28 at 15 28 52](https://user-images.githubusercontent.com/14048037/221958863-cde32680-8280-4200-90e1-543c59c2ce20.png)

We found that the main error was that the first week of April was broken apart into two different weeks. On closer inspection, it turned out that the reason for this was our local daylight saving time change, which occurs on the first Saturday of April. On the `_lastDayofWeek` method, when doing the following operation:

`firstDayOfWeek.add(Duration(days: restOfWeek))`

instead of returning the correct date at 00:00, it returns the previous day at 23:00, because during that week we turn our clocks back one hour. Our proposed solution handles this by using a new method to add days that makes sure to just add the correct number of days and doesn't make time adjustments. By using this method, the problem is solved:

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-28 at 15 39 07](https://user-images.githubusercontent.com/14048037/221959011-5bd42cb1-1766-4743-9ccd-a616f3aa79ba.png)




