### PR TITLE
feat: add optional padding parameter to calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,16 @@ PagedVerticalCalendar(
   dayBuilder: (context, date) {
     // provide a day widget
   },
+  calendarBottomPadding: //provide a bottom padding value
+  calendarTopPadding: //provide a top padding value,
 );
 ```
 
 * `monthBuilder` provides the year and month as `integers`. this builder has to return a widget that will form the header of ever month. the [intl](https://pub.dev/packages/intl) package works well here for date formatting.
 
-* `dayBuilder` provides the day as a `DateTime`. this builder wil be called for every day. You usually want to provide at least a text widget with the current day number. 
+* `dayBuilder` provides the day as a `DateTime`. this builder wil be called for every day. You usually want to provide at least a text widget with the current day number.
+
+* `calendarBottomPadding` and `calendarTopPadding` provide a way for the calendar to have vertical padding.
 
 ## :wave: Get Involved
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ PagedVerticalCalendar(
   dayBuilder: (context, date) {
     // provide a day widget
   },
-  calendarBottomPadding: //provide a bottom padding value
-  calendarTopPadding: //provide a top padding value,
+  listPadding: // provide EdgeInset value
 );
 ```
 
@@ -87,7 +86,7 @@ PagedVerticalCalendar(
 
 * `dayBuilder` provides the day as a `DateTime`. this builder wil be called for every day. You usually want to provide at least a text widget with the current day number.
 
-* `calendarBottomPadding` and `calendarTopPadding` provide a way for the calendar to have vertical padding.
+* `listPadding` can be provided in case you need the list to have padding.
 
 ## :wave: Get Involved
 

--- a/lib/paged_vertical_calendar.dart
+++ b/lib/paged_vertical_calendar.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart' hide DateUtils;
-import 'package:flutter/rendering.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:paged_vertical_calendar/utils/date_models.dart';
 import 'package:paged_vertical_calendar/utils/date_utils.dart';
@@ -42,7 +41,7 @@ class PagedVerticalCalendar extends StatefulWidget {
     this.invisibleMonthsThreshold = 1,
     this.physics,
     this.scrollController,
-    this.listPadding = EdgeInsets.zero,
+    this.calendarPadding = EdgeInsets.zero,
     this.startWeekWithSunday = false,
   }) : this.initialDate = initialDate ?? DateTime.now().removeTime();
 
@@ -89,8 +88,8 @@ class PagedVerticalCalendar extends StatefulWidget {
   /// how many months should be loaded outside of the view. defaults to `1`
   final int invisibleMonthsThreshold;
 
-  /// list padding, defaults to `EdgeInsets.zero`
-  final EdgeInsetsGeometry listPadding;
+  /// calendar padding, defaults to `EdgeInsets.zero`
+  final EdgeInsetsGeometry calendarPadding;
 
   /// scroll physics, defaults to matching platform conventions
   final ScrollPhysics? physics;
@@ -227,47 +226,42 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
 
   @override
   Widget build(BuildContext context) {
-    return Scrollable(
-      controller: widget.scrollController,
-      physics: widget.physics,
-      viewportBuilder: (BuildContext context, ViewportOffset position) {
-        return Viewport(
-          offset: position,
-          center: downListKey,
-          slivers: [
-            if (!hideUp)
-              PagedSliverList(
-                pagingController: _pagingReplyUpController,
-                builderDelegate: PagedChildBuilderDelegate<Month>(
-                  itemBuilder: (BuildContext context, Month month, int index) {
-                    return _MonthView(
-                      month: month,
-                      monthBuilder: widget.monthBuilder,
-                      dayBuilder: widget.dayBuilder,
-                      onDayPressed: widget.onDayPressed,
-                      startWeekWithSunday: widget.startWeekWithSunday,
-                    );
-                  },
+    return CustomScrollView(
+      slivers: [
+        SliverPadding(
+          padding: widget.calendarPadding,
+          sliver: hideUp
+              ? PagedSliverList(
+                  key: downListKey,
+                  pagingController: _pagingReplyDownController,
+                  builderDelegate: PagedChildBuilderDelegate<Month>(
+                    itemBuilder: (BuildContext context, Month month, int index) {
+                      return _MonthView(
+                        month: month,
+                        monthBuilder: widget.monthBuilder,
+                        dayBuilder: widget.dayBuilder,
+                        onDayPressed: widget.onDayPressed,
+                        startWeekWithSunday: widget.startWeekWithSunday,
+                      );
+                    },
+                  ),
+                )
+              : PagedSliverList(
+                  pagingController: _pagingReplyUpController,
+                  builderDelegate: PagedChildBuilderDelegate<Month>(
+                    itemBuilder: (BuildContext context, Month month, int index) {
+                      return _MonthView(
+                        month: month,
+                        monthBuilder: widget.monthBuilder,
+                        dayBuilder: widget.dayBuilder,
+                        onDayPressed: widget.onDayPressed,
+                        startWeekWithSunday: widget.startWeekWithSunday,
+                      );
+                    },
+                  ),
                 ),
-              ),
-            PagedSliverList(
-              key: downListKey,
-              pagingController: _pagingReplyDownController,
-              builderDelegate: PagedChildBuilderDelegate<Month>(
-                itemBuilder: (BuildContext context, Month month, int index) {
-                  return _MonthView(
-                    month: month,
-                    monthBuilder: widget.monthBuilder,
-                    dayBuilder: widget.dayBuilder,
-                    onDayPressed: widget.onDayPressed,
-                    startWeekWithSunday: widget.startWeekWithSunday,
-                  );
-                },
-              ),
-            ),
-          ],
-        );
-      },
+        )
+      ],
     );
   }
 

--- a/lib/paged_vertical_calendar.dart
+++ b/lib/paged_vertical_calendar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart' hide DateUtils;
+import 'package:flutter/rendering.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:paged_vertical_calendar/utils/date_models.dart';
 import 'package:paged_vertical_calendar/utils/date_utils.dart';
@@ -41,7 +42,8 @@ class PagedVerticalCalendar extends StatefulWidget {
     this.invisibleMonthsThreshold = 1,
     this.physics,
     this.scrollController,
-    this.calendarPadding = EdgeInsets.zero,
+    this.calendarBottomPadding = 0,
+    this.calendarTopPadding = 0,
     this.startWeekWithSunday = false,
   }) : this.initialDate = initialDate ?? DateTime.now().removeTime();
 
@@ -88,8 +90,11 @@ class PagedVerticalCalendar extends StatefulWidget {
   /// how many months should be loaded outside of the view. defaults to `1`
   final int invisibleMonthsThreshold;
 
-  /// calendar padding, defaults to `EdgeInsets.zero`
-  final EdgeInsetsGeometry calendarPadding;
+  /// calendar bottom padding, defaults to `0`
+  final double calendarBottomPadding;
+
+  /// calendar top padding, defaults to `0`
+  final double calendarTopPadding;
 
   /// scroll physics, defaults to matching platform conventions
   final ScrollPhysics? physics;
@@ -226,44 +231,53 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
 
   @override
   Widget build(BuildContext context) {
-    return CustomScrollView(
+    return Scrollable(
       controller: widget.scrollController,
       physics: widget.physics,
-      slivers: [
-        SliverPadding(
-          padding: widget.calendarPadding,
-          sliver: hideUp
-              ? PagedSliverList(
-                  key: downListKey,
-                  pagingController: _pagingReplyDownController,
-                  builderDelegate: PagedChildBuilderDelegate<Month>(
-                    itemBuilder: (BuildContext context, Month month, int index) {
-                      return _MonthView(
-                        month: month,
-                        monthBuilder: widget.monthBuilder,
-                        dayBuilder: widget.dayBuilder,
-                        onDayPressed: widget.onDayPressed,
-                        startWeekWithSunday: widget.startWeekWithSunday,
-                      );
-                    },
-                  ),
-                )
-              : PagedSliverList(
-                  pagingController: _pagingReplyUpController,
-                  builderDelegate: PagedChildBuilderDelegate<Month>(
-                    itemBuilder: (BuildContext context, Month month, int index) {
-                      return _MonthView(
-                        month: month,
-                        monthBuilder: widget.monthBuilder,
-                        dayBuilder: widget.dayBuilder,
-                        onDayPressed: widget.onDayPressed,
-                        startWeekWithSunday: widget.startWeekWithSunday,
-                      );
-                    },
-                  ),
+      viewportBuilder: (BuildContext context, ViewportOffset position) {
+        return Viewport(
+          offset: position,
+          center: downListKey,
+          slivers: [
+            SliverToBoxAdapter(
+              child: SizedBox(height: widget.calendarTopPadding),
+            ),
+            if (!hideUp)
+              PagedSliverList(
+                pagingController: _pagingReplyUpController,
+                builderDelegate: PagedChildBuilderDelegate<Month>(
+                  itemBuilder: (BuildContext context, Month month, int index) {
+                    return _MonthView(
+                      month: month,
+                      monthBuilder: widget.monthBuilder,
+                      dayBuilder: widget.dayBuilder,
+                      onDayPressed: widget.onDayPressed,
+                      startWeekWithSunday: widget.startWeekWithSunday,
+                    );
+                  },
                 ),
-        )
-      ],
+              ),
+            PagedSliverList(
+              key: downListKey,
+              pagingController: _pagingReplyDownController,
+              builderDelegate: PagedChildBuilderDelegate<Month>(
+                itemBuilder: (BuildContext context, Month month, int index) {
+                  return _MonthView(
+                    month: month,
+                    monthBuilder: widget.monthBuilder,
+                    dayBuilder: widget.dayBuilder,
+                    onDayPressed: widget.onDayPressed,
+                    startWeekWithSunday: widget.startWeekWithSunday,
+                  );
+                },
+              ),
+            ),
+            SliverToBoxAdapter(
+              child: SizedBox(height: widget.calendarBottomPadding),
+            ),
+          ],
+        );
+      },
     );
   }
 

--- a/lib/paged_vertical_calendar.dart
+++ b/lib/paged_vertical_calendar.dart
@@ -42,8 +42,7 @@ class PagedVerticalCalendar extends StatefulWidget {
     this.invisibleMonthsThreshold = 1,
     this.physics,
     this.scrollController,
-    this.calendarBottomPadding = 0,
-    this.calendarTopPadding = 0,
+    this.listPadding = EdgeInsets.zero,
     this.startWeekWithSunday = false,
   }) : this.initialDate = initialDate ?? DateTime.now().removeTime();
 
@@ -90,11 +89,8 @@ class PagedVerticalCalendar extends StatefulWidget {
   /// how many months should be loaded outside of the view. defaults to `1`
   final int invisibleMonthsThreshold;
 
-  /// calendar bottom padding, defaults to `0`
-  final double calendarBottomPadding;
-
-  /// calendar top padding, defaults to `0`
-  final double calendarTopPadding;
+  /// list padding, defaults to `0`
+  final EdgeInsets listPadding;
 
   /// scroll physics, defaults to matching platform conventions
   final ScrollPhysics? physics;
@@ -229,6 +225,11 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
     }
   }
 
+  EdgeInsets _getDownListPadding() {
+    final double paddingTop = hideUp ? widget.listPadding.top : 0;
+    return EdgeInsets.fromLTRB(widget.listPadding.left, paddingTop, widget.listPadding.right, widget.listPadding.bottom);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scrollable(
@@ -239,42 +240,42 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
           offset: position,
           center: downListKey,
           slivers: [
-            SliverToBoxAdapter(
-              child: SizedBox(height: widget.calendarTopPadding),
-            ),
             if (!hideUp)
-              PagedSliverList(
-                pagingController: _pagingReplyUpController,
-                builderDelegate: PagedChildBuilderDelegate<Month>(
-                  itemBuilder: (BuildContext context, Month month, int index) {
-                    return _MonthView(
-                      month: month,
-                      monthBuilder: widget.monthBuilder,
-                      dayBuilder: widget.dayBuilder,
-                      onDayPressed: widget.onDayPressed,
-                      startWeekWithSunday: widget.startWeekWithSunday,
-                    );
-                  },
+              SliverPadding(
+                padding: EdgeInsets.fromLTRB(widget.listPadding.left, widget.listPadding.top, widget.listPadding.right, 0),
+                sliver: PagedSliverList(
+                  pagingController: _pagingReplyUpController,
+                  builderDelegate: PagedChildBuilderDelegate<Month>(
+                    itemBuilder: (BuildContext context, Month month, int index) {
+                      return _MonthView(
+                        month: month,
+                        monthBuilder: widget.monthBuilder,
+                        dayBuilder: widget.dayBuilder,
+                        onDayPressed: widget.onDayPressed,
+                        startWeekWithSunday: widget.startWeekWithSunday,
+                      );
+                    },
+                  ),
                 ),
               ),
-            PagedSliverList(
-              key: downListKey,
-              pagingController: _pagingReplyDownController,
-              builderDelegate: PagedChildBuilderDelegate<Month>(
-                itemBuilder: (BuildContext context, Month month, int index) {
-                  return _MonthView(
-                    month: month,
-                    monthBuilder: widget.monthBuilder,
-                    dayBuilder: widget.dayBuilder,
-                    onDayPressed: widget.onDayPressed,
-                    startWeekWithSunday: widget.startWeekWithSunday,
-                  );
-                },
+              SliverPadding(
+                key: downListKey,
+                padding: _getDownListPadding(),
+                sliver: PagedSliverList(
+                  pagingController: _pagingReplyDownController,
+                  builderDelegate: PagedChildBuilderDelegate<Month>(
+                    itemBuilder: (BuildContext context, Month month, int index) {
+                      return _MonthView(
+                        month: month,
+                        monthBuilder: widget.monthBuilder,
+                        dayBuilder: widget.dayBuilder,
+                        onDayPressed: widget.onDayPressed,
+                        startWeekWithSunday: widget.startWeekWithSunday,
+                      );
+                    },
+                  ),
+                ),
               ),
-            ),
-            SliverToBoxAdapter(
-              child: SizedBox(height: widget.calendarBottomPadding),
-            ),
           ],
         );
       },

--- a/lib/paged_vertical_calendar.dart
+++ b/lib/paged_vertical_calendar.dart
@@ -227,6 +227,8 @@ class _PagedVerticalCalendarState extends State<PagedVerticalCalendar> {
   @override
   Widget build(BuildContext context) {
     return CustomScrollView(
+      controller: widget.scrollController,
+      physics: widget.physics,
       slivers: [
         SliverPadding(
           padding: widget.calendarPadding,


### PR DESCRIPTION
Hi! We wanted to have an option to give the calendar some padding. What we were specifically looking for, was a way for the calendar to have a bottom margin, but we decided it would be more useful to have a flexible parameter that just worked with whatever `EdgeInsets` it was given. The use case for this feature can vary depending on the UI. In our case, we had a bottom sheet that, when popped up, almost completely covered the last month of the calendar.

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-28 at 16 19 17](https://user-images.githubusercontent.com/14048037/221959139-3a0d7f52-7e61-4759-923e-e48c0f10e216.png)

The change we made allows for the calendar to have an additional space, like this:

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-28 at 16 22 08](https://user-images.githubusercontent.com/14048037/221959772-9ab92083-5e81-448b-be6c-f44024fd9751.png)
