### PR TITLE
update of infinite_scroll_pagination to 4.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  infinite_scroll_pagination: ^3.2.0
+  infinite_scroll_pagination: ^4.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Updated dependency, so it will be available for flutter 2.5+

fix of https://github.com/casvanluijtelaar/paged_vertical_calendar/issues/42